### PR TITLE
Removes relative_permalinks that are no longer supported by jekyll

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+lucasmbraz.com

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 
 # Syntax highlighting
-highlighter:         pygments
+highlighter:         rouge
 
 # Permalinks
 permalink:           /:title

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,5 @@
 
 # Syntax highlighting
-markdown:            redcarpet
 highlighter:         pygments
 
 # Permalinks

--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,6 @@ highlighter:         rouge
 
 # Permalinks
 permalink:           /:title
-relative_permalinks: true
 
 # Setup
 timezone:            your timezone # eg. Asia/Kathmandu
@@ -15,7 +14,7 @@ tagline:             'tagline'
 description:         'description'
 url:                 site url
 rss:                 rss feed url
-baseurl:             '/'
+baseurl:             ''
 baseurl_posts_img:   '/assets/images/posts/'
 baseurl_featured_img: '/assets/images/hero/'
 baseurl_featured_thumbnail: '/assets/images/thumbnail/'

--- a/_includes/footer-scripts.html
+++ b/_includes/footer-scripts.html
@@ -1,10 +1,10 @@
 <!-- Javascript -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
-<script src="{{ site.baseurl_javascripts }}imagesloaded.pkgd.min.js"></script>
+<script src="{{ site.baseurl }}{{ site.baseurl_javascripts }}imagesloaded.pkgd.min.js"></script>
 
 {% if page.syntaxHighlighter %}
-  <script src="{{ site.baseurl_javascripts }}prism.js"></script>
-  <script src="{{ site.baseurl_javascripts }}plugins/prism-line-numbers.min.js"></script>
+  <script src="{{ site.baseurl }}{{ site.baseurl_javascripts }}prism.js"></script>
+  <script src="{{ site.baseurl }}{{ site.baseurl_javascripts }}plugins/prism-line-numbers.min.js"></script>
 {% endif %}
 
 <script>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,7 +1,7 @@
 <footer class="section--footer">
   <div class="container container--content">
     <div>
-      <a href="{{ site.baseurl }}humans.txt">Hand-crafted</a> by <a href="{{ site.baseurl }}about/">Your Name</a>
+      <a href="{{ site.baseurl }}/humans.txt">Hand-crafted</a> by <a href="{{ site.baseurl }}/about/">Your Name</a>
     </div>
     <ul class="socialAccountList">
       <li><a href="http://twitter.com/{{ site.author.twitter }}" class="socialAccount socialAccount--twitter" target="_blank"></a></li>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -30,14 +30,14 @@
   <meta name="twitter:creator" content="@{{ site.author.twitter }}">
   <meta name="twitter:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.name }}{% endif %}">
   <meta name="twitter:description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
-  <meta name="twitter:image" content="{% if page.image.feature %}{{ page.image.feature | prepend: site.baseurl_featured_img | prepend: site.url }}{% else %}{{ site.icon | prepend: site.baseurl | prepend: site.url }}{% endif %}">
+  <meta name="twitter:image" content="{% if page.image.feature %}{{ site.url }}{{ site.baseurl }}{{ site.baseurl_featured_img }}{{ page.image.feature }}{% else %}{{ site.icon | prepend: site.baseurl | prepend: site.url }}{% endif %}">
   <meta name="twitter:url" content="{{ page.url | replace:'index.html','' | prepend: site.url }}">
 
   <!-- Open graph -->
   <meta property="og:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.name }}{% endif %}">
   <meta property="og:type" content="{% if page.date %}article{% else %}website{% endif %}">
   <meta property="og:url" content="{{ page.url | replace:'index.html','' | prepend: site.url }}">
-  <meta property="og:image" content="{% if page.image.feature %}{{ page.image.feature | prepend: site.baseurl_featured_img | prepend: site.url }}{% else %}{{ site.icon | prepend: site.baseurl | prepend: site.url }}{% endif %}">
+  <meta property="og:image" content="{% if page.image.feature %}{{ site.url }}{{ site.baseurl }}{{ site.baseurl_featured_img }}{{ page.image.feature }}{% else %}{{ site.icon | prepend: site.baseurl | prepend: site.url }}{% endif %}">
   <meta property="og:description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
   <meta property="og:site_name" content="{{ site.name }}">
   <meta property="og:locale" content="{{ site.locale }}">
@@ -75,11 +75,11 @@
   </title>
 
   <!-- CSS -->
-  <link rel="stylesheet" href="{{ site.baseurl }}assets/css/main.css">
+  <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/main.css">
 
   {% if page.syntaxHighlighter %}
-    <link rel="stylesheet" href="{{ site.baseurl }}assets/css/prism-okaidia.css">
-    <link rel="stylesheet" href="{{ site.baseurl }}assets/css/prism-line-numbers.css">
+    <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/prism-okaidia.css">
+    <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/prism-line-numbers.css">
   {% endif %}
 
   <!-- Fonts -->
@@ -88,8 +88,8 @@
   <link href='http://fonts.googleapis.com/css?family=PT+Sans:700' rel='stylesheet' type='text/css'>
 
   <!-- Icons -->
-  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ site.baseurl }}assets/apple-touch-icon-144-precomposed.png">
-  <link rel="shortcut icon" href="{{ site.baseurl }}assets/images/favicon.ico">
+  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ site.baseurl }}/assets/apple-touch-icon-144-precomposed.png">
+  <link rel="shortcut icon" href="{{ site.baseurl }}/assets/images/favicon.ico">
 
   <!-- RSS -->
   <link rel="alternate" type="application/rss+xml" title="RSS" href="/feed.xml">

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -1,7 +1,7 @@
 <nav class="menuWrapper">
   <ul class="popover popover--menu">
     <li class="menu-avatar">
-      <a href="{{ site.baseurl }}" class="brandLogo brandLogo--small
+      <a href="{{ site.baseurl }}/" class="brandLogo brandLogo--small
       {% if page.bgContrast == "light" %}
         brandLogo--black
       {% endif %}

--- a/_includes/modal.html
+++ b/_includes/modal.html
@@ -11,13 +11,13 @@
   <div class="u-tableCell u-verticalAlignMiddle">
     <h2 class="h2--shareTitle">Share this story</h2>
     <ul class="shareWrapper">
-      <li><a class="shareButton shareButton--twitter" href="https://twitter.com/intent/tweet?text={{ page.title | append: ' by @VincentChan' }}&url={{ page.url | prepend: site.url | url_encode }}" target="_blank"></a></li>
-      <li><a class="shareButton shareButton--facebook" href="https://www.facebook.com/sharer/sharer.php?u={{ page.url | prepend: site.url | url_encode }}" target="_blank"></a></li>
+      <li><a class="shareButton shareButton--twitter" href="https://twitter.com/intent/tweet?text={{ page.title | append: ' by @VincentChan' }}&url={{ page.url | prepend: site.baseurl | prepend: site.url | url_encode }}" target="_blank"></a></li>
+      <li><a class="shareButton shareButton--facebook" href="https://www.facebook.com/sharer/sharer.php?u={{ page.url | prepend: site.baseurl | prepend: site.url | url_encode }}" target="_blank"></a></li>
       <li><a class="shareButton shareButton--linkedin" href="https://www.linkedin.com/shareArticle
-?mini=true&url={{ page.url | prepend: site.url | url_encode }}&title={{ page.title }}"  target="_blank"></a></li>
-      <li><a class="shareButton shareButton--buffer" href="https://buffer.com/add?text={{ page.title | append: ' by @VincentChan' }}&url={{ page.url | prepend: site.url | url_encode }}" target="_blank"></a></li>
-      <li><a class="shareButton shareButton--hackernews" href="http://news.ycombinator.com/submitlink?u={{ page.url | prepend: site.url | url_encode }}&t={{ page.title }}" target="_blank"></a></li>
-      <li><a class="shareButton shareButton--pocket" href="https://getpocket.com/save?url={{ page.url | prepend: site.url | url_encode }}&title={{ page.title }}" target="_blank"></a></li>
+?mini=true&url={{ page.url | prepend: site.baseurl | prepend: site.url | url_encode }}&title={{ page.title }}"  target="_blank"></a></li>
+      <li><a class="shareButton shareButton--buffer" href="https://buffer.com/add?text={{ page.title | append: ' by @VincentChan' }}&url={{ page.url | prepend: site.baseurl | prepend: site.url | url_encode }}" target="_blank"></a></li>
+      <li><a class="shareButton shareButton--hackernews" href="http://news.ycombinator.com/submitlink?u={{ page.url | prepend: site.baseurl | prepend: site.url | url_encode }}&t={{ page.title }}" target="_blank"></a></li>
+      <li><a class="shareButton shareButton--pocket" href="https://getpocket.com/save?url={{ page.url | prepend: site.baseurl | prepend: site.url | url_encode }}&title={{ page.title }}" target="_blank"></a></li>
     </ul>
   </div>
 </div>

--- a/_includes/sidebar-nav.html
+++ b/_includes/sidebar-nav.html
@@ -1,5 +1,5 @@
 <nav role="navigation" class="sidebar sidebar--right">
-  <a href="{{site.baseurl}}" class="textLogo textLogo--white textLogo--sidebar">{{ site.name }}</a>
+  <a href="{{ site.baseurl }}/" class="textLogo textLogo--white textLogo--sidebar">{{ site.name }}</a>
   <ul class="sidebar-recentPosts">
     {% for post in site.posts offset:0 limit:10 %}
       {% if post.title == page.title %}
@@ -7,11 +7,11 @@
       {% else %}
       <li>
         {% if post.image.feature %}
-          <a href="{{ post.url }}" class="sidebar-recentPosts-image-wrapper">
-            <img src="{{ post.image.feature | prepend: site.baseurl_featured_thumbnail }}" style="" alt="">
+          <a href="{{ site.baseurl }}{{ post.url }}" class="sidebar-recentPosts-image-wrapper">
+            <img src="{{ site.baseurl }}{{ site.baseurl_featured_thumbnail }}{{ post.image.feature }}" style="" alt="">
           </a>
         {% endif %}
-        <a href="{{ post.url }}">{{ post.title }}</a>
+        <a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a>
         <div class="postMeta">{{ post.date | date_to_string }}</div>
       </li>
       {% endif %}

--- a/_includes/subscribe.html
+++ b/_includes/subscribe.html
@@ -2,7 +2,7 @@
   <div class="container container--content">
     <h3 class="u-alignCenter">Stay in touch</h3>
     <p>
-      Hi, I'm <a href="{{ site.baseurl }}about/">Your Name</a>. A short description of your blog. Mickey is a minimal one-column theme for Jekyll. It's designed and developed by <a href="http://github.com/vincentchan" target="_blank">@VincentChan</a>. 
+      Hi, I'm <a href="{{ site.baseurl }}/about/">Your Name</a>. A short description of your blog. Mickey is a minimal one-column theme for Jekyll. It's designed and developed by <a href="http://github.com/vincentchan" target="_blank">@VincentChan</a>. 
     </p>
     <div class="newsletterForm-wrapper">
       <!-- Begin MailChimp Signup Form -->

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,7 +4,7 @@
   {% include head.html %}
 
   <body>
-    {% if page.url != '/index.html' %}
+    {% if page.url != "/" %}
       <input type="checkbox" class="sidebar-checkbox" id="sidebar-checkbox">
       {% include sidebar-nav.html %}
       {% include menu.html %}
@@ -12,11 +12,11 @@
 
     {{ content }}
 
-    {% if page.url != '/index.html' %}
+    {% if page.url != "/" %}
       {% include sidebar-toggle.html %}
     {% endif %}
 
-    {% if page.url == '/index.html' %}
+    {% if page.url == "/" %}
       {% include subscribe.html %}
       {% include footer.html %}
     {% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -6,7 +6,7 @@ layout: default
     <div class="section-backgroundImage">
 
       {% if page.image.feature %}
-        <img class="post-featuredImage" src="{{ page.image.feature | prepend: site.baseurl_featured_img }}" style="
+        <img class="post-featuredImage" src="{{ site.baseurl }}{{ site.baseurl_featured_img }}{{ page.image.feature }}" style="
         {% if page.image.topPosition %}
           top:{{ page.image.topPosition }};
         {% endif %}
@@ -66,7 +66,7 @@ layout: default
         <div class="section-backgroundImage section-backgroundImage--previousPage">
           <img class="post-featuredImage"
           {% if page.previous.image.feature %}
-            src="{{ page.previous.image.feature | prepend: site.baseurl_featured_img }}"
+            src="{{ site.baseurl }}{{ site.baseurl_featured_img }}{{ page.previous.image.feature }}"
           {% endif %}
           style="top:0" alt="">
         </div>
@@ -80,7 +80,7 @@ layout: default
         <div class="section-title u-tableCell u-verticalAlignMiddle">
           <div class="container">
             <h4>Next story:</h4>
-            <a class="prev" href="{{page.previous.url}}">
+            <a class="prev" href="{{ site.baseurl }}{{page.previous.url}}">
               <h2>{{page.previous.title}}</h2>
             </a>
           </div>

--- a/_posts/2014-12-15-a-life-of-walt-disney.markdown
+++ b/_posts/2014-12-15-a-life-of-walt-disney.markdown
@@ -25,7 +25,7 @@ Disney died from lung cancer on December 15, 1966, in Burbank, California. He le
 
 #### Childhood
 
-<div class="img img--fullContainer img--14xLeading" style="background-image: url({{ site.baseurl_posts_img }}walt-childhood.jpg);"></div>
+<div class="img img--fullContainer img--14xLeading" style="background-image: url({{ site.baseurl }}{{ site.baseurl_posts_img }}walt-childhood.jpg);"></div>
 
 Disney was born on December 5, 1901, at 2156 North Tripp Avenue in Chicago's Hermosa community area, to Elias Charles Disney, who was Irish-Canadian, and Flora Call Disney, who was of German and English descent. His great-grandfather, Arundel Elias Disney, had emigrated from Gowran, County Kilkenny, Ireland where he was born in 1801. Arundel Disney was a descendant of Robert d'Isigny, a Frenchman who had travelled to England with William the Conqueror in 1066. With the d'Isigny name anglicized as "Disney", the family settled in the English village now known as Norton Disney, south of the city of Lincoln, in the county of Lincolnshire.
 

--- a/index.html
+++ b/index.html
@@ -28,17 +28,17 @@ title: Mickey Theme for Jekyll
             <div class="postArticle-wrapper">
               <article class="postArticle postArticle--short">
                 {% if post.image.feature %}
-                  <a href="{{ post.url }}">
-                    <div class="postArticle-image desaturate" style="background-image:url('{{ post.image.feature | prepend: site.baseurl_featured_img }}')">
+                  <a href="{{ site.baseurl }}{{ post.url }}">
+                    <div class="postArticle-image desaturate" style="background-image:url('{{ site.baseurl }}{{ site.baseurl_featured_img }}{{ post.image.feature }}')">
                     </div>
                   </a>
                 {% else %}
-                <a href="{{ post.url }}">
+                <a href="{{ site.baseurl }}{{ post.url }}">
                   <div class="postArticle-image" style="background-image:url('{{site.baseurl}}assets/images/logo-black.svg')">
                   </div>
                 </a>
                 {% endif %}
-                <a class="postArticle-title" href="{{ post.url }}">{{ post.title }}</a>
+                <a class="postArticle-title" href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a>
               </article>
               <div class="block-postMeta">{{ post.date | date_to_string }}</div>
             </div>


### PR DESCRIPTION
Hi, 

I really liked your theme but when I tried it jekyll couldn't build it because of relative_permalinks=true on the config file. Also, github pages no longer uses redcarpet and doesn't support pygments highlighter.

This is my attempt at fixing it. It seems to work for me but I'm not a web dev so I'm not very sure. 

I followed this to fix the broken links http://downtothewire.io/2015/08/15/configuring-jekyll-for-user-and-project-github-pages/